### PR TITLE
System :sepolicy: Fix bootloop on TWRP restore

### DIFF
--- a/prebuilts/api/29.0/public/domain.te
+++ b/prebuilts/api/29.0/public/domain.te
@@ -486,7 +486,8 @@ neverallow { domain -kernel with_asan(`-asan_extract') } { system_file_type vend
 
 # Don't allow mounting on top of /system files or directories
 neverallow * exec_type:dir_file_class_set mounton;
-neverallow { domain -init } { system_file_type vendor_file_type }:dir_file_class_set mounton;
+neverallow { domain -init } { system_file_type vendor_file_type }:file_class_set mounton;
+neverallow { domain -init -zygote} { system_file_type vendor_file_type }:dir mounton;
 
 # Nothing should be writing to files in the rootfs, except recovery.
 neverallow { domain -recovery } rootfs:file { create write setattr relabelto append unlink link rename };

--- a/public/domain.te
+++ b/public/domain.te
@@ -491,11 +491,12 @@ neverallow { domain -init } { system_file_type vendor_file_type }:file_class_set
 neverallow { domain -init -zygote} { system_file_type vendor_file_type }:dir mounton;
 
 # Nothing should be writing to files in the rootfs, except recovery.
-neverallow { domain -recovery } rootfs:file { create write setattr relabelto append unlink link rename };
+neverallow { domain -recovery } rootfs:file {  relabelto append link };
+neverallow { domain -recovery -update_engine} rootfs:file { write create setattr unlink rename };
 
 # Restrict context mounts to specific types marked with
 # the contextmount_type attribute.
-neverallow * {fs_type -contextmount_type -sdcard_posix_contextmount_type}:filesystem relabelto;
+neverallow ~vold {fs_type -contextmount_type -sdcard_posix_contextmount_type}:filesystem relabelto;
 
 # Ensure that context mount types are not writable, to ensure that
 # the write to /system restriction above is not bypassed via context=

--- a/public/domain.te
+++ b/public/domain.te
@@ -487,7 +487,8 @@ neverallow { domain -kernel -update_engine with_asan(`-asan_extract') } { system
 
 # Don't allow mounting on top of /system files or directories
 neverallow * exec_type:dir_file_class_set mounton;
-neverallow { domain -init userdebug_or_eng(`-recovery') } { system_file_type vendor_file_type }:dir_file_class_set mounton;
+neverallow { domain -init } { system_file_type vendor_file_type }:file_class_set mounton;
+neverallow { domain -init -zygote} { system_file_type vendor_file_type }:dir mounton;
 
 # Nothing should be writing to files in the rootfs, except recovery.
 neverallow { domain -recovery } rootfs:file { create write setattr relabelto append unlink link rename };


### PR DESCRIPTION
sepolicy on system : Fix bootloop on TWRP restore

When TWRP restores a ROM backup, the root directory now has the wrong
selinux
context "system_file" instead of "rootfs" as it should be for Q
system-as-root.

Attempting to boot the restored ROM results in the following
error/denial
and will bootloop if the ROM is enforcing.

Therefore, added sepolicy/vendor/zygote.te on device tree.
As result, neverallow rule on domain.te must change.